### PR TITLE
Polling user

### DIFF
--- a/sdk/src/accounts/defaultClearingHouseAccountSubscriber.ts
+++ b/sdk/src/accounts/defaultClearingHouseAccountSubscriber.ts
@@ -31,10 +31,10 @@ export class DefaultClearingHouseAccountSubscriber
 
 	subscribers: Map<
 		SubscribableClearingHouseAccountTypes,
-		PollingWebSocketAccountSubscriber<SubscribableAccount>
+		PollingWebSocketAccountSubscriber<SubscribableAccount, SubscribableClearingHouseAccountTypes>
 	> = new Map<
 		SubscribableClearingHouseAccountTypes,
-		PollingWebSocketAccountSubscriber<SubscribableAccount>
+		PollingWebSocketAccountSubscriber<SubscribableAccount, SubscribableClearingHouseAccountTypes>
 	>();
 
 	private isSubscribing = false;
@@ -56,8 +56,8 @@ export class DefaultClearingHouseAccountSubscriber
 			throw new Error('account is not subscribed ' + account);
 		}
 
-		return this.subscribers.get(account).startPolling(() => {
-			this.eventEmitter.emit('fetchedAccount', account);
+		return this.subscribers.get(account).startPolling((accountType) => {
+			this.eventEmitter.emit('fetchedAccount', accountType);
 		});
 		
 	}
@@ -98,7 +98,7 @@ export class DefaultClearingHouseAccountSubscriber
 		// create and activate main state account subscription
 		this.subscribers.set(
 			'stateAccount',
-			new PollingWebSocketAccountSubscriber('state', this.program, statePublicKey)
+			new PollingWebSocketAccountSubscriber('stateAccount', 'state', this.program, statePublicKey)
 		);
 		await this.subscribers
 			.get('stateAccount')
@@ -111,7 +111,7 @@ export class DefaultClearingHouseAccountSubscriber
 
 		this.subscribers.set(
 			'marketsAccount',
-			new PollingWebSocketAccountSubscriber('markets', this.program, state.markets)
+			new PollingWebSocketAccountSubscriber('marketsAccount', 'markets', this.program, state.markets)
 		);
 
 		await this.subscribers
@@ -125,7 +125,7 @@ export class DefaultClearingHouseAccountSubscriber
 
 		this.subscribers.set(
 			'tradeHistoryAccount',
-			new PollingWebSocketAccountSubscriber(
+			new PollingWebSocketAccountSubscriber('tradeHistoryAccount',
 				'tradeHistory',
 				this.program,
 				state.tradeHistory
@@ -134,7 +134,7 @@ export class DefaultClearingHouseAccountSubscriber
 
 		this.subscribers.set(
 			'depositHistoryAccount',
-			new PollingWebSocketAccountSubscriber(
+			new PollingWebSocketAccountSubscriber('depositHistoryAccount',
 				'depositHistory',
 				this.program,
 				state.depositHistory
@@ -143,7 +143,7 @@ export class DefaultClearingHouseAccountSubscriber
 
 		this.subscribers.set(
 			'fundingPaymentHistoryAccount',
-			new PollingWebSocketAccountSubscriber(
+			new PollingWebSocketAccountSubscriber('fundingPaymentHistoryAccount',
 				'fundingPaymentHistory',
 				this.program,
 				state.fundingPaymentHistory
@@ -152,7 +152,7 @@ export class DefaultClearingHouseAccountSubscriber
 
 		this.subscribers.set(
 			'fundingRateHistoryAccount',
-			new PollingWebSocketAccountSubscriber(
+			new PollingWebSocketAccountSubscriber('fundingRateHistoryAccount',
 				'fundingRateHistory',
 				this.program,
 				state.fundingRateHistory
@@ -161,7 +161,7 @@ export class DefaultClearingHouseAccountSubscriber
 
 		this.subscribers.set(
 			'liquidationHistoryAccount',
-			new PollingWebSocketAccountSubscriber(
+			new PollingWebSocketAccountSubscriber('liquidationHistoryAccount',
 				'liquidationHistory',
 				this.program,
 				state.liquidationHistory
@@ -170,7 +170,7 @@ export class DefaultClearingHouseAccountSubscriber
 
 		this.subscribers.set(
 			'curveHistoryAccount',
-			new PollingWebSocketAccountSubscriber(
+			new PollingWebSocketAccountSubscriber('curveHistoryAccount',
 				'curveHistory',
 				this.program,
 				state.curveHistory

--- a/sdk/src/accounts/defaultClearingHouseAccountSubscriber.ts
+++ b/sdk/src/accounts/defaultClearingHouseAccountSubscriber.ts
@@ -30,9 +30,19 @@ export class DefaultClearingHouseAccountSubscriber
 	program: Program;
 	eventEmitter: StrictEventEmitter<EventEmitter, ClearingHouseAccountEvents>;
 
-	pollRate: Map<SubscribableClearingHouseAccountTypes, number> = new Map<SubscribableClearingHouseAccountTypes, number>();
-	pollInterval: Map<SubscribableClearingHouseAccountTypes, NodeJS.Timer> = new Map<SubscribableClearingHouseAccountTypes, NodeJS.Timer>();
-	subscribers: Map<SubscribableClearingHouseAccountTypes, AccountSubscriber<SubscribableAccount>> = new Map<SubscribableClearingHouseAccountTypes, AccountSubscriber<SubscribableAccount>>();
+	pollRate: Map<SubscribableClearingHouseAccountTypes, number> = new Map<
+		SubscribableClearingHouseAccountTypes,
+		number
+	>();
+	pollInterval: Map<SubscribableClearingHouseAccountTypes, NodeJS.Timer> =
+		new Map<SubscribableClearingHouseAccountTypes, NodeJS.Timer>();
+	subscribers: Map<
+		SubscribableClearingHouseAccountTypes,
+		AccountSubscriber<SubscribableAccount>
+	> = new Map<
+		SubscribableClearingHouseAccountTypes,
+		AccountSubscriber<SubscribableAccount>
+	>();
 
 	private isSubscribing = false;
 	private subscriptionPromise: Promise<boolean>;
@@ -45,7 +55,7 @@ export class DefaultClearingHouseAccountSubscriber
 	}
 
 	startPolling(account: SubscribableClearingHouseAccountTypes): boolean {
-		if (this.pollInterval.has(account)) {	
+		if (this.pollInterval.has(account)) {
 			throw new Error('already polling ' + account);
 		}
 		if (!this.pollRate.has(account)) {
@@ -57,13 +67,18 @@ export class DefaultClearingHouseAccountSubscriber
 		if (!this.subscribers.get(account).isSubscribed) {
 			throw new Error('account is not subscribed ' + account);
 		}
-		this.pollInterval.set(account, setInterval(() => {
-			this.subscribers.get(account).fetch().then(() => {
-				this.eventEmitter.emit('fetchedAccount', account);
-			});
-		}, this.pollRate.get(account)));
+		this.pollInterval.set(
+			account,
+			setInterval(() => {
+				this.subscribers
+					.get(account)
+					.fetch()
+					.then(() => {
+						this.eventEmitter.emit('fetchedAccount', account);
+					});
+			}, this.pollRate.get(account))
+		);
 		return true;
-		
 	}
 
 	stopPolling(account: SubscribableClearingHouseAccountTypes): boolean {
@@ -73,10 +88,12 @@ export class DefaultClearingHouseAccountSubscriber
 			return true;
 		}
 		return false;
-		
 	}
 
-	setPollingRate(account: SubscribableClearingHouseAccountTypes, rate: number): void {
+	setPollingRate(
+		account: SubscribableClearingHouseAccountTypes,
+		rate: number
+	): void {
 		this.pollRate.set(account, rate);
 	}
 
@@ -102,77 +119,98 @@ export class DefaultClearingHouseAccountSubscriber
 		);
 
 		// create and activate main state account subscription
-		this.subscribers.set('stateAccount', new WebSocketAccountSubscriber(
-			'state',
-			this.program,
-			statePublicKey
-		));
-		await this.subscribers.get('stateAccount').subscribe((data: StateAccount) => {
-			this.eventEmitter.emit('stateAccountUpdate', data);
-			this.eventEmitter.emit('update');
-		});
+		this.subscribers.set(
+			'stateAccount',
+			new WebSocketAccountSubscriber('state', this.program, statePublicKey)
+		);
+		await this.subscribers
+			.get('stateAccount')
+			.subscribe((data: StateAccount) => {
+				this.eventEmitter.emit('stateAccountUpdate', data);
+				this.eventEmitter.emit('update');
+			});
 
 		const state = this.subscribers.get('stateAccount').data as StateAccount;
 
-		this.subscribers.set('marketsAccount', new WebSocketAccountSubscriber(
-			'markets',
-			this.program,
-			state.markets
-		));
+		this.subscribers.set(
+			'marketsAccount',
+			new WebSocketAccountSubscriber('markets', this.program, state.markets)
+		);
 
-		await this.subscribers.get('marketsAccount').subscribe((data: MarketsAccount) => {
-			this.eventEmitter.emit('marketsAccountUpdate', data);
-			this.eventEmitter.emit('update');
-		});
+		await this.subscribers
+			.get('marketsAccount')
+			.subscribe((data: MarketsAccount) => {
+				this.eventEmitter.emit('marketsAccountUpdate', data);
+				this.eventEmitter.emit('update');
+			});
 
 		// create subscribers for other state accounts
 
-		this.subscribers.set('tradeHistoryAccount', new WebSocketAccountSubscriber(
-			'tradeHistory',
-			this.program,
-			state.tradeHistory
-		));
+		this.subscribers.set(
+			'tradeHistoryAccount',
+			new WebSocketAccountSubscriber(
+				'tradeHistory',
+				this.program,
+				state.tradeHistory
+			)
+		);
 
-		this.subscribers.set('depositHistoryAccount', new WebSocketAccountSubscriber(
-			'depositHistory',
-			this.program,
-			state.depositHistory
-		));
+		this.subscribers.set(
+			'depositHistoryAccount',
+			new WebSocketAccountSubscriber(
+				'depositHistory',
+				this.program,
+				state.depositHistory
+			)
+		);
 
-		this.subscribers.set('fundingPaymentHistoryAccount', 
+		this.subscribers.set(
+			'fundingPaymentHistoryAccount',
 			new WebSocketAccountSubscriber(
 				'fundingPaymentHistory',
 				this.program,
 				state.fundingPaymentHistory
-			));
+			)
+		);
 
-		this.subscribers.set('fundingRateHistoryAccount', new WebSocketAccountSubscriber(
-			'fundingRateHistory',
-			this.program,
-			state.fundingRateHistory
-		));
+		this.subscribers.set(
+			'fundingRateHistoryAccount',
+			new WebSocketAccountSubscriber(
+				'fundingRateHistory',
+				this.program,
+				state.fundingRateHistory
+			)
+		);
 
-		this.subscribers.set('liquidationHistoryAccount', new WebSocketAccountSubscriber(
-			'liquidationHistory',
-			this.program,
-			state.liquidationHistory
-		));
+		this.subscribers.set(
+			'liquidationHistoryAccount',
+			new WebSocketAccountSubscriber(
+				'liquidationHistory',
+				this.program,
+				state.liquidationHistory
+			)
+		);
 
-		this.subscribers.set('curveHistoryAccount', new WebSocketAccountSubscriber(
-			'curveHistory',
-			this.program,
-			state.curveHistory
-		));
+		this.subscribers.set(
+			'curveHistoryAccount',
+			new WebSocketAccountSubscriber(
+				'curveHistory',
+				this.program,
+				state.curveHistory
+			)
+		);
 
-
-
-		await Promise.all(optionalSubscriptions.map(accountType => {
-			return this.subscribers.get(accountType).subscribe(data => {
-				this.eventEmitter.emit(((accountType+'Update') as keyof OptionalSubscribableAccount), data);
-				this.eventEmitter.emit('update');
-			});
-		}));
-
+		await Promise.all(
+			optionalSubscriptions.map((accountType) => {
+				return this.subscribers.get(accountType).subscribe((data) => {
+					this.eventEmitter.emit(
+						(accountType + 'Update') as keyof OptionalSubscribableAccount,
+						data
+					);
+					this.eventEmitter.emit('update');
+				});
+			})
+		);
 
 		this.eventEmitter.emit('update');
 
@@ -188,13 +226,15 @@ export class DefaultClearingHouseAccountSubscriber
 			return;
 		}
 
-		await Promise.all([...this.subscribers.values()].filter(accountSubscriber => accountSubscriber.isSubscribed)
-		.map((accountSubscriber) => {
-			return accountSubscriber.fetch();
-		}));
+		await Promise.all(
+			[...this.subscribers.values()]
+				.filter((accountSubscriber) => accountSubscriber.isSubscribed)
+				.map((accountSubscriber) => {
+					return accountSubscriber.fetch();
+				})
+		);
 
 		this.eventEmitter.emit('fetched');
-
 	}
 
 	public async unsubscribe(): Promise<void> {
@@ -202,9 +242,13 @@ export class DefaultClearingHouseAccountSubscriber
 			return;
 		}
 
-		await Promise.all([...this.subscribers.values()].filter(accountSubscriber => accountSubscriber.isSubscribed).map(accountSubscriber => {
-			return accountSubscriber.unsubscribe();
-		}));
+		await Promise.all(
+			[...this.subscribers.values()]
+				.filter((accountSubscriber) => accountSubscriber.isSubscribed)
+				.map((accountSubscriber) => {
+					return accountSubscriber.unsubscribe();
+				})
+		);
 
 		this.isSubscribed = false;
 	}
@@ -246,36 +290,42 @@ export class DefaultClearingHouseAccountSubscriber
 	public getTradeHistoryAccount(): TradeHistoryAccount {
 		this.assertIsSubscribed();
 		this.assertOptionalIsSubscribed('tradeHistoryAccount');
-		return this.subscribers.get('tradeHistoryAccount').data as TradeHistoryAccount;
+		return this.subscribers.get('tradeHistoryAccount')
+			.data as TradeHistoryAccount;
 	}
 
 	public getDepositHistoryAccount(): DepositHistoryAccount {
 		this.assertIsSubscribed();
 		this.assertOptionalIsSubscribed('depositHistoryAccount');
-		return this.subscribers.get('depositHistoryAccount').data as DepositHistoryAccount;
+		return this.subscribers.get('depositHistoryAccount')
+			.data as DepositHistoryAccount;
 	}
 
 	public getFundingPaymentHistoryAccount(): FundingPaymentHistoryAccount {
 		this.assertIsSubscribed();
 		this.assertOptionalIsSubscribed('fundingPaymentHistoryAccount');
-		return this.subscribers.get('fundingPaymentHistoryAccount').data as FundingPaymentHistoryAccount;
+		return this.subscribers.get('fundingPaymentHistoryAccount')
+			.data as FundingPaymentHistoryAccount;
 	}
 
 	public getFundingRateHistoryAccount(): FundingRateHistoryAccount {
 		this.assertIsSubscribed();
 		this.assertOptionalIsSubscribed('fundingRateHistoryAccount');
-		return this.subscribers.get('fundingRateHistoryAccount').data as FundingRateHistoryAccount;
+		return this.subscribers.get('fundingRateHistoryAccount')
+			.data as FundingRateHistoryAccount;
 	}
 
 	public getCurveHistoryAccount(): CurveHistoryAccount {
 		this.assertIsSubscribed();
 		this.assertOptionalIsSubscribed('curveHistoryAccount');
-		return this.subscribers.get('curveHistoryAccount').data as CurveHistoryAccount;
+		return this.subscribers.get('curveHistoryAccount')
+			.data as CurveHistoryAccount;
 	}
 
 	public getLiquidationHistoryAccount(): LiquidationHistoryAccount {
 		this.assertIsSubscribed();
 		this.assertOptionalIsSubscribed('liquidationHistoryAccount');
-		return this.subscribers.get('liquidationHistoryAccount').data as LiquidationHistoryAccount;
+		return this.subscribers.get('liquidationHistoryAccount')
+			.data as LiquidationHistoryAccount;
 	}
 }

--- a/sdk/src/accounts/defaultClearingHouseAccountSubscriber.ts
+++ b/sdk/src/accounts/defaultClearingHouseAccountSubscriber.ts
@@ -31,10 +31,16 @@ export class DefaultClearingHouseAccountSubscriber
 
 	subscribers: Map<
 		SubscribableClearingHouseAccountTypes,
-		PollingWebSocketAccountSubscriber<SubscribableAccount, SubscribableClearingHouseAccountTypes>
+		PollingWebSocketAccountSubscriber<
+			SubscribableAccount,
+			SubscribableClearingHouseAccountTypes
+		>
 	> = new Map<
 		SubscribableClearingHouseAccountTypes,
-		PollingWebSocketAccountSubscriber<SubscribableAccount, SubscribableClearingHouseAccountTypes>
+		PollingWebSocketAccountSubscriber<
+			SubscribableAccount,
+			SubscribableClearingHouseAccountTypes
+		>
 	>();
 
 	private isSubscribing = false;
@@ -48,7 +54,6 @@ export class DefaultClearingHouseAccountSubscriber
 	}
 
 	startPolling(account: SubscribableClearingHouseAccountTypes): boolean {
-
 		if (!this.subscribers.has(account)) {
 			throw new Error('could not find subscriber ' + account);
 		}
@@ -59,12 +64,10 @@ export class DefaultClearingHouseAccountSubscriber
 		return this.subscribers.get(account).startPolling((accountType) => {
 			this.eventEmitter.emit('fetchedAccount', accountType);
 		});
-		
 	}
 
 	stopPolling(account: SubscribableClearingHouseAccountTypes): boolean {
 		return this.subscribers.get(account).stopPolling();
-
 	}
 
 	setPollingRate(
@@ -98,7 +101,12 @@ export class DefaultClearingHouseAccountSubscriber
 		// create and activate main state account subscription
 		this.subscribers.set(
 			'stateAccount',
-			new PollingWebSocketAccountSubscriber('stateAccount', 'state', this.program, statePublicKey)
+			new PollingWebSocketAccountSubscriber(
+				'stateAccount',
+				'state',
+				this.program,
+				statePublicKey
+			)
 		);
 		await this.subscribers
 			.get('stateAccount')
@@ -111,7 +119,12 @@ export class DefaultClearingHouseAccountSubscriber
 
 		this.subscribers.set(
 			'marketsAccount',
-			new PollingWebSocketAccountSubscriber('marketsAccount', 'markets', this.program, state.markets)
+			new PollingWebSocketAccountSubscriber(
+				'marketsAccount',
+				'markets',
+				this.program,
+				state.markets
+			)
 		);
 
 		await this.subscribers
@@ -125,7 +138,8 @@ export class DefaultClearingHouseAccountSubscriber
 
 		this.subscribers.set(
 			'tradeHistoryAccount',
-			new PollingWebSocketAccountSubscriber('tradeHistoryAccount',
+			new PollingWebSocketAccountSubscriber(
+				'tradeHistoryAccount',
 				'tradeHistory',
 				this.program,
 				state.tradeHistory
@@ -134,7 +148,8 @@ export class DefaultClearingHouseAccountSubscriber
 
 		this.subscribers.set(
 			'depositHistoryAccount',
-			new PollingWebSocketAccountSubscriber('depositHistoryAccount',
+			new PollingWebSocketAccountSubscriber(
+				'depositHistoryAccount',
 				'depositHistory',
 				this.program,
 				state.depositHistory
@@ -143,7 +158,8 @@ export class DefaultClearingHouseAccountSubscriber
 
 		this.subscribers.set(
 			'fundingPaymentHistoryAccount',
-			new PollingWebSocketAccountSubscriber('fundingPaymentHistoryAccount',
+			new PollingWebSocketAccountSubscriber(
+				'fundingPaymentHistoryAccount',
 				'fundingPaymentHistory',
 				this.program,
 				state.fundingPaymentHistory
@@ -152,7 +168,8 @@ export class DefaultClearingHouseAccountSubscriber
 
 		this.subscribers.set(
 			'fundingRateHistoryAccount',
-			new PollingWebSocketAccountSubscriber('fundingRateHistoryAccount',
+			new PollingWebSocketAccountSubscriber(
+				'fundingRateHistoryAccount',
 				'fundingRateHistory',
 				this.program,
 				state.fundingRateHistory
@@ -161,7 +178,8 @@ export class DefaultClearingHouseAccountSubscriber
 
 		this.subscribers.set(
 			'liquidationHistoryAccount',
-			new PollingWebSocketAccountSubscriber('liquidationHistoryAccount',
+			new PollingWebSocketAccountSubscriber(
+				'liquidationHistoryAccount',
 				'liquidationHistory',
 				this.program,
 				state.liquidationHistory
@@ -170,7 +188,8 @@ export class DefaultClearingHouseAccountSubscriber
 
 		this.subscribers.set(
 			'curveHistoryAccount',
-			new PollingWebSocketAccountSubscriber('curveHistoryAccount',
+			new PollingWebSocketAccountSubscriber(
+				'curveHistoryAccount',
 				'curveHistory',
 				this.program,
 				state.curveHistory
@@ -179,7 +198,7 @@ export class DefaultClearingHouseAccountSubscriber
 
 		await Promise.all(
 			optionalSubscriptions.map((accountType) => {
-				switch(accountType) {
+				switch (accountType) {
 					case 'curveHistoryAccount':
 						return this.subscribers.get(accountType).subscribe((data) => {
 							this.eventEmitter.emit(

--- a/sdk/src/accounts/defaultUserAccountSubscriber.ts
+++ b/sdk/src/accounts/defaultUserAccountSubscriber.ts
@@ -25,10 +25,16 @@ export class DefaultUserAccountSubscriber
 
 	subscribers: Map<
 		SubscribableUserAccountTypes,
-		PollingWebSocketAccountSubscriber<OptionalSubscribableUserAccount, SubscribableUserAccountTypes>
+		PollingWebSocketAccountSubscriber<
+			OptionalSubscribableUserAccount,
+			SubscribableUserAccountTypes
+		>
 	> = new Map<
 		SubscribableUserAccountTypes,
-		PollingWebSocketAccountSubscriber<OptionalSubscribableUserAccount, SubscribableUserAccountTypes>
+		PollingWebSocketAccountSubscriber<
+			OptionalSubscribableUserAccount,
+			SubscribableUserAccountTypes
+		>
 	>();
 
 	public constructor(program: Program, authority: PublicKey) {
@@ -39,14 +45,12 @@ export class DefaultUserAccountSubscriber
 	}
 
 	startPolling(account: SubscribableUserAccountTypes): boolean {
-
 		if (!this.subscribers.has(account)) {
 			throw new Error('could not find subscriber ' + account);
 		}
 		if (!this.subscribers.get(account).isSubscribed) {
 			throw new Error('account is not subscribed ' + account);
 		}
-
 
 		return this.subscribers.get(account).startPolling((accountType) => {
 			this.eventEmitter.emit('fetchedAccount', accountType);
@@ -55,13 +59,9 @@ export class DefaultUserAccountSubscriber
 
 	stopPolling(account: SubscribableUserAccountTypes): boolean {
 		return this.subscribers.get(account).stopPolling();
-
 	}
 
-	setPollingRate(
-		account: SubscribableUserAccountTypes,
-		rate: number
-	): void {
+	setPollingRate(account: SubscribableUserAccountTypes, rate: number): void {
 		this.subscribers.get(account).setPollingRate(rate);
 	}
 
@@ -78,8 +78,8 @@ export class DefaultUserAccountSubscriber
 			'userAccount',
 			new PollingWebSocketAccountSubscriber(
 				'userAccount',
-				'user', 
-				this.program, 
+				'user',
+				this.program,
 				userPublicKey
 			)
 		);

--- a/sdk/src/accounts/defaultUserAccountSubscriber.ts
+++ b/sdk/src/accounts/defaultUserAccountSubscriber.ts
@@ -25,10 +25,10 @@ export class DefaultUserAccountSubscriber
 
 	subscribers: Map<
 		SubscribableUserAccountTypes,
-		PollingWebSocketAccountSubscriber<OptionalSubscribableUserAccount>
+		PollingWebSocketAccountSubscriber<OptionalSubscribableUserAccount, SubscribableUserAccountTypes>
 	> = new Map<
 		SubscribableUserAccountTypes,
-		PollingWebSocketAccountSubscriber<OptionalSubscribableUserAccount>
+		PollingWebSocketAccountSubscriber<OptionalSubscribableUserAccount, SubscribableUserAccountTypes>
 	>();
 
 	public constructor(program: Program, authority: PublicKey) {
@@ -48,8 +48,8 @@ export class DefaultUserAccountSubscriber
 		}
 
 
-		return this.subscribers.get(account).startPolling(() => {
-			this.eventEmitter.emit('fetchedAccount', account);
+		return this.subscribers.get(account).startPolling((accountType) => {
+			this.eventEmitter.emit('fetchedAccount', accountType);
 		});
 	}
 
@@ -76,7 +76,12 @@ export class DefaultUserAccountSubscriber
 		);
 		this.subscribers.set(
 			'userAccount',
-			new PollingWebSocketAccountSubscriber('user', this.program, userPublicKey)
+			new PollingWebSocketAccountSubscriber(
+				'userAccount',
+				'user', 
+				this.program, 
+				userPublicKey
+			)
 		);
 		await this.subscribers.get('userAccount').subscribe((data: UserAccount) => {
 			this.eventEmitter.emit('userAccountUpdate', data);
@@ -89,6 +94,7 @@ export class DefaultUserAccountSubscriber
 		this.subscribers.set(
 			'userPositionsAccount',
 			new PollingWebSocketAccountSubscriber(
+				'userPositionsAccount',
 				'userPositions',
 				this.program,
 				userAccountData.positions

--- a/sdk/src/accounts/defaultUserAccountSubscriber.ts
+++ b/sdk/src/accounts/defaultUserAccountSubscriber.ts
@@ -71,6 +71,7 @@ export class DefaultUserAccountSubscriber implements UserAccountSubscriber {
 			this.userDataAccountSubscriber.fetch(),
 			this.userPositionsAccountSubscriber.fetch(),
 		]);
+		this.eventEmitter.emit('fetched');
 	}
 
 	async unsubscribe(): Promise<void> {

--- a/sdk/src/accounts/defaultUserAccountSubscriber.ts
+++ b/sdk/src/accounts/defaultUserAccountSubscriber.ts
@@ -1,8 +1,8 @@
 import {
 	AccountSubscriber,
 	NotSubscribedError,
-	UserAccountEvents,
-	UserAccountSubscriber,
+	PollingUserAccountSubscriber,
+	UserAccountEvents
 } from './types';
 import { Program } from '@project-serum/anchor';
 import StrictEventEmitter from 'strict-event-emitter-types';
@@ -11,21 +11,59 @@ import { PublicKey } from '@solana/web3.js';
 import { getUserAccountPublicKey } from '../addresses';
 import { WebSocketAccountSubscriber } from './webSocketAccountSubscriber';
 import { UserAccount, UserPositionsAccount } from '../types';
+import { OptionalSubscribableUserAccount, SubscribableUserAccountTypes } from '..';
 
-export class DefaultUserAccountSubscriber implements UserAccountSubscriber {
+export class DefaultUserAccountSubscriber implements PollingUserAccountSubscriber {
 	isSubscribed: boolean;
 	program: Program;
 	eventEmitter: StrictEventEmitter<EventEmitter, UserAccountEvents>;
 	authority: PublicKey;
 
-	userDataAccountSubscriber: AccountSubscriber<UserAccount>;
-	userPositionsAccountSubscriber: AccountSubscriber<UserPositionsAccount>;
+	pollRate: Map<SubscribableUserAccountTypes, number> = new Map<SubscribableUserAccountTypes, number>();
+	pollInterval: Map<SubscribableUserAccountTypes, NodeJS.Timer> = new Map<SubscribableUserAccountTypes, NodeJS.Timer>();
+	subscribers: Map<SubscribableUserAccountTypes, AccountSubscriber<OptionalSubscribableUserAccount>> = new Map<SubscribableUserAccountTypes, AccountSubscriber<OptionalSubscribableUserAccount>>();
 
 	public constructor(program: Program, authority: PublicKey) {
 		this.isSubscribed = false;
 		this.program = program;
 		this.authority = authority;
 		this.eventEmitter = new EventEmitter();
+	}
+
+	startPolling(account: SubscribableUserAccountTypes): boolean {
+		if (this.pollInterval.has(account)) {	
+			throw new Error('already polling ' + account);
+		}
+		if (!this.pollRate.has(account)) {
+			throw new Error('no poll rate set for ' + account);
+		}
+		if (!this.subscribers.has(account)) {
+			throw new Error('could not find subscriber ' + account);
+		}
+		if (!this.subscribers.get(account).isSubscribed) {
+			throw new Error('account is not subscribed ' + account);
+		}
+		this.pollInterval.set(account, setInterval(() => {
+			this.subscribers.get(account).fetch().then(() => {
+				this.eventEmitter.emit('fetchedAccount', account);
+			});
+		}, this.pollRate.get(account)));
+		return true;
+		
+	}
+
+	stopPolling(account: SubscribableUserAccountTypes): boolean {
+		if (this.pollInterval.has(account)) {
+			clearInterval(this.pollInterval.get(account));
+			this.pollInterval.delete(account);
+			return true;
+		}
+		return false;
+		
+	}
+
+	setPollingRate(account: SubscribableUserAccountTypes, rate: number): void {
+		this.pollRate.set(account, rate);
 	}
 
 	async subscribe(): Promise<boolean> {
@@ -37,24 +75,25 @@ export class DefaultUserAccountSubscriber implements UserAccountSubscriber {
 			this.program.programId,
 			this.authority
 		);
-		this.userDataAccountSubscriber = new WebSocketAccountSubscriber(
+		this.subscribers.set('userAccount', new WebSocketAccountSubscriber(
 			'user',
 			this.program,
 			userPublicKey
-		);
-		await this.userDataAccountSubscriber.subscribe((data: UserAccount) => {
+		));
+		await this.subscribers.get('userAccount').subscribe((data: UserAccount) => {
 			this.eventEmitter.emit('userAccountData', data);
 			this.eventEmitter.emit('update');
 		});
 
-		const userAccountData = this.userDataAccountSubscriber.data;
-		this.userPositionsAccountSubscriber = new WebSocketAccountSubscriber(
+		const userAccountData = this.subscribers.get('userAccount').data as UserAccount;
+
+		this.subscribers.set('userPositionsAccount', new WebSocketAccountSubscriber(
 			'userPositions',
 			this.program,
 			userAccountData.positions
-		);
+		));
 
-		await this.userPositionsAccountSubscriber.subscribe(
+		await this.subscribers.get('userPositionsAccount').subscribe(
 			(data: UserPositionsAccount) => {
 				this.eventEmitter.emit('userPositionsData', data);
 				this.eventEmitter.emit('update');
@@ -67,10 +106,9 @@ export class DefaultUserAccountSubscriber implements UserAccountSubscriber {
 	}
 
 	async fetch(): Promise<void> {
-		await Promise.all([
-			this.userDataAccountSubscriber.fetch(),
-			this.userPositionsAccountSubscriber.fetch(),
-		]);
+		await Promise.all([...this.subscribers.values()].filter(accountSubscriber => accountSubscriber.isSubscribed).map(accountSubscriber => {
+			return accountSubscriber.fetch();
+		}));
 		this.eventEmitter.emit('fetched');
 	}
 
@@ -79,27 +117,34 @@ export class DefaultUserAccountSubscriber implements UserAccountSubscriber {
 			return;
 		}
 
-		this.userDataAccountSubscriber.unsubscribe();
-		this.userPositionsAccountSubscriber.unsubscribe();
+		await Promise.all([...this.subscribers.values()].filter(accountSubscriber => {
+			return accountSubscriber.isSubscribed;
+		}).map(accountSubscriber => {
+			return accountSubscriber.unsubscribe();
+		}));
 
 		this.isSubscribed = false;
 	}
 
-	assertIsSubscribed(): void {
+	assertIsSubscribed(account: SubscribableUserAccountTypes): void {
 		if (!this.isSubscribed) {
 			throw new NotSubscribedError(
 				'You must call `subscribe` before using this function'
+			);
+		} else if (!this.subscribers.get(account).isSubscribed) {
+			throw new NotSubscribedError(
+				'Account ' + account.toString() + ' is not subscribed'
 			);
 		}
 	}
 
 	public getUserAccount(): UserAccount {
-		this.assertIsSubscribed();
-		return this.userDataAccountSubscriber.data;
+		this.assertIsSubscribed('userAccount');
+		return this.subscribers.get('userAccount').data as UserAccount;
 	}
 
 	public getUserPositionsAccount(): UserPositionsAccount {
-		this.assertIsSubscribed();
-		return this.userPositionsAccountSubscriber.data;
+		this.assertIsSubscribed('userPositionsAccount');
+		return this.subscribers.get('userPositionsAccount').data as UserPositionsAccount;
 	}
 }

--- a/sdk/src/accounts/pollingWebSocketAccountSubscriber.ts
+++ b/sdk/src/accounts/pollingWebSocketAccountSubscriber.ts
@@ -1,28 +1,30 @@
-
 import { Program } from '@project-serum/anchor';
 import { PublicKey } from '@solana/web3.js';
 import { WebSocketAccountSubscriber } from './webSocketAccountSubscriber';
 
-export class PollingWebSocketAccountSubscriber<T, S> extends WebSocketAccountSubscriber<T> {
+export class PollingWebSocketAccountSubscriber<
+	T,
+	S
+> extends WebSocketAccountSubscriber<T> {
 	isSubscribed: boolean;
 	data?: T;
-    accountType: S;
+	accountType: S;
 	accountName: string;
 	program: Program;
 	accountPublicKey: PublicKey;
-    pollInterval: NodeJS.Timer;
-    pollRate: number;
+	pollInterval: NodeJS.Timer;
+	pollRate: number;
 	onChange: (data: T) => void;
-    onFetch: (accountType: S) => void;
+	onFetch: (accountType: S) => void;
 
 	public constructor(
-        accountType: S,
+		accountType: S,
 		accountName: string,
 		program: Program,
 		accountPublicKey: PublicKey
 	) {
 		super(accountName, program, accountPublicKey);
-        this.accountType = accountType;
+		this.accountType = accountType;
 	}
 
 	async subscribe(onChange: (data: T) => void): Promise<void> {
@@ -49,17 +51,16 @@ export class PollingWebSocketAccountSubscriber<T, S> extends WebSocketAccountSub
 		}
 	}
 
-
-    startPolling(onFetch: (account: S) => void): boolean {
-        if (this.pollInterval != null) {
-            throw new Error('already polling ' + this.accountType);
-        }
-        this.onFetch = onFetch;
+	startPolling(onFetch: (account: S) => void): boolean {
+		if (this.pollInterval != null) {
+			throw new Error('already polling ' + this.accountType);
+		}
+		this.onFetch = onFetch;
 		this.pollInterval = setInterval(() => {
-            this.fetch().then(() => {
-                this.onFetch(this.accountType);
-            });
-        }, this.pollRate);
+			this.fetch().then(() => {
+				this.onFetch(this.accountType);
+			});
+		}, this.pollRate);
 		return true;
 	}
 
@@ -74,9 +75,6 @@ export class PollingWebSocketAccountSubscriber<T, S> extends WebSocketAccountSub
 	setPollingRate(rate: number): void {
 		this.pollRate = rate;
 	}
-
-
-
 
 	unsubscribe(): Promise<void> {
 		const unsubscribed = this.program.account[this.accountName].unsubscribe(

--- a/sdk/src/accounts/pollingWebSocketAccountSubscriber.ts
+++ b/sdk/src/accounts/pollingWebSocketAccountSubscriber.ts
@@ -3,23 +3,26 @@ import { Program } from '@project-serum/anchor';
 import { PublicKey } from '@solana/web3.js';
 import { WebSocketAccountSubscriber } from './webSocketAccountSubscriber';
 
-export class PollingWebSocketAccountSubscriber<T> extends WebSocketAccountSubscriber<T> {
+export class PollingWebSocketAccountSubscriber<T, S> extends WebSocketAccountSubscriber<T> {
 	isSubscribed: boolean;
 	data?: T;
+    accountType: S;
 	accountName: string;
 	program: Program;
 	accountPublicKey: PublicKey;
     pollInterval: NodeJS.Timer;
     pollRate: number;
 	onChange: (data: T) => void;
-    onFetch: (accountType: string) => void;
+    onFetch: (accountType: S) => void;
 
 	public constructor(
+        accountType: S,
 		accountName: string,
 		program: Program,
 		accountPublicKey: PublicKey
 	) {
 		super(accountName, program, accountPublicKey);
+        this.accountType = accountType;
 	}
 
 	async subscribe(onChange: (data: T) => void): Promise<void> {
@@ -47,14 +50,14 @@ export class PollingWebSocketAccountSubscriber<T> extends WebSocketAccountSubscr
 	}
 
 
-    startPolling(onFetch: (account: string) => void): boolean {
+    startPolling(onFetch: (account: S) => void): boolean {
         if (this.pollInterval != null) {
-            throw new Error('already polling ' + this.accountName);
+            throw new Error('already polling ' + this.accountType);
         }
         this.onFetch = onFetch;
 		this.pollInterval = setInterval(() => {
             this.fetch().then(() => {
-                this.onFetch(this.accountName);
+                this.onFetch(this.accountType);
             });
         }, this.pollRate);
 		return true;

--- a/sdk/src/accounts/pollingWebSocketAccountSubscriber.ts
+++ b/sdk/src/accounts/pollingWebSocketAccountSubscriber.ts
@@ -1,0 +1,85 @@
+
+import { Program } from '@project-serum/anchor';
+import { PublicKey } from '@solana/web3.js';
+import { WebSocketAccountSubscriber } from './webSocketAccountSubscriber';
+
+export class PollingWebSocketAccountSubscriber<T> extends WebSocketAccountSubscriber<T> {
+	isSubscribed: boolean;
+	data?: T;
+	accountName: string;
+	program: Program;
+	accountPublicKey: PublicKey;
+    pollInterval: NodeJS.Timer;
+    pollRate: number;
+	onChange: (data: T) => void;
+    onFetch: (accountType: string) => void;
+
+	public constructor(
+		accountName: string,
+		program: Program,
+		accountPublicKey: PublicKey
+	) {
+		super(accountName, program, accountPublicKey);
+	}
+
+	async subscribe(onChange: (data: T) => void): Promise<void> {
+		this.onChange = onChange;
+		await this.fetch();
+		this.isSubscribed = true;
+		this.program.account[this.accountName]
+			.subscribe(this.accountPublicKey, this.program.provider.opts.commitment)
+			.on('change', async (data: T) => {
+				this.data = data;
+				this.onChange(data);
+			});
+	}
+
+	async fetch(): Promise<void> {
+		const newData = (await this.program.account[this.accountName].fetch(
+			this.accountPublicKey
+		)) as T;
+
+		// if data has changed trigger update
+		if (JSON.stringify(newData) !== JSON.stringify(this.data)) {
+			this.data = newData;
+			this.onChange(this.data);
+		}
+	}
+
+
+    startPolling(onFetch: (account: string) => void): boolean {
+        if (this.pollInterval != null) {
+            throw new Error('already polling ' + this.accountName);
+        }
+        this.onFetch = onFetch;
+		this.pollInterval = setInterval(() => {
+            this.fetch().then(() => {
+                this.onFetch(this.accountName);
+            });
+        }, this.pollRate);
+		return true;
+	}
+
+	stopPolling(): boolean {
+		if (this.pollInterval != null) {
+			clearInterval(this.pollInterval);
+			return true;
+		}
+		return false;
+	}
+
+	setPollingRate(rate: number): void {
+		this.pollRate = rate;
+	}
+
+
+
+
+	unsubscribe(): Promise<void> {
+		const unsubscribed = this.program.account[this.accountName].unsubscribe(
+			this.accountPublicKey
+		);
+		this.isSubscribed = false;
+		return unsubscribed;
+	}
+}

--- a/sdk/src/accounts/types.ts
+++ b/sdk/src/accounts/types.ts
@@ -69,6 +69,7 @@ export interface ClearingHouseAccountSubscriber {
 }
 
 export interface UserAccountEvents {
+	fetched: void;
 	userAccountData: (payload: UserAccount) => void;
 	userPositionsData: (payload: UserPositionsAccount) => void;
 	update: void;

--- a/sdk/src/accounts/types.ts
+++ b/sdk/src/accounts/types.ts
@@ -41,16 +41,22 @@ export interface ClearingHouseAccountEvents {
 	fetchedAccount: SubscribableClearingHouseAccountTypes;
 }
 
-export type OptionalSubscribableClearingHouseAccountTypes = 'tradeHistoryAccount'
+export type OptionalSubscribableClearingHouseAccountTypes =
+	| 'tradeHistoryAccount'
 	| 'depositHistoryAccount'
 	| 'fundingPaymentHistoryAccount'
 	| 'fundingRateHistoryAccount'
 	| 'curveHistoryAccount'
 	| 'liquidationHistoryAccount';
 
-export type SubscribableClearingHouseAccountTypes = 'stateAccount' | 'marketsAccount' | & OptionalSubscribableClearingHouseAccountTypes;
+export type SubscribableClearingHouseAccountTypes =
+	| 'stateAccount'
+	| 'marketsAccount'
+	| OptionalSubscribableClearingHouseAccountTypes;
 
-export type SubscribableUserAccountTypes = 'userAccount' | 'userPositionsAccount';
+export type SubscribableUserAccountTypes =
+	| 'userAccount'
+	| 'userPositionsAccount';
 
 export interface ClearingHouseAccountSubscriber {
 	eventEmitter: StrictEventEmitter<EventEmitter, ClearingHouseAccountEvents>;
@@ -93,16 +99,17 @@ export interface UserAccountSubscriber {
 }
 
 export interface PollingUserAccountSubscriber extends UserAccountSubscriber {
-
-	startPolling(account: SubscribableUserAccountTypes): boolean
-	stopPolling(account: SubscribableUserAccountTypes): boolean
-	setPollingRate(account: SubscribableUserAccountTypes, rate: number): void
+	startPolling(account: SubscribableUserAccountTypes): boolean;
+	stopPolling(account: SubscribableUserAccountTypes): boolean;
+	setPollingRate(account: SubscribableUserAccountTypes, rate: number): void;
 }
 
-
-export interface PollingClearingHouseAccountSubscriber extends ClearingHouseAccountSubscriber {
-
-	startPolling(account: SubscribableClearingHouseAccountTypes): boolean
-	stopPolling(account: SubscribableClearingHouseAccountTypes): boolean
-	setPollingRate(account: SubscribableClearingHouseAccountTypes, rate: number): void
+export interface PollingClearingHouseAccountSubscriber
+	extends ClearingHouseAccountSubscriber {
+	startPolling(account: SubscribableClearingHouseAccountTypes): boolean;
+	stopPolling(account: SubscribableClearingHouseAccountTypes): boolean;
+	setPollingRate(
+		account: SubscribableClearingHouseAccountTypes,
+		rate: number
+	): void;
 }

--- a/sdk/src/accounts/types.ts
+++ b/sdk/src/accounts/types.ts
@@ -14,6 +14,7 @@ import StrictEventEmitter from 'strict-event-emitter-types';
 import { EventEmitter } from 'events';
 
 export interface AccountSubscriber<T> {
+	isSubscribed: boolean;
 	data?: T;
 	subscribe(onChange: (data: T) => void): Promise<void>;
 	fetch(): Promise<void>;
@@ -36,24 +37,27 @@ export interface ClearingHouseAccountEvents {
 	depositHistoryAccountUpdate: (payload: DepositHistoryAccount) => void;
 	curveHistoryAccountUpdate: (payload: CurveHistoryAccount) => void;
 	update: void;
+	fetched: void;
+	fetchedAccount: SubscribableClearingHouseAccountTypes;
 }
 
-export type ClearingHouseAccountTypes =
-	| 'tradeHistoryAccount'
+export type OptionalSubscribableClearingHouseAccountTypes = 'tradeHistoryAccount'
 	| 'depositHistoryAccount'
 	| 'fundingPaymentHistoryAccount'
 	| 'fundingRateHistoryAccount'
 	| 'curveHistoryAccount'
 	| 'liquidationHistoryAccount';
 
+export type SubscribableClearingHouseAccountTypes = 'stateAccount' | 'marketsAccount' | & OptionalSubscribableClearingHouseAccountTypes;
+
+export type SubscribableUserAccountTypes = 'userAccount' | 'userPositionsAccount';
+
 export interface ClearingHouseAccountSubscriber {
 	eventEmitter: StrictEventEmitter<EventEmitter, ClearingHouseAccountEvents>;
 	isSubscribed: boolean;
 
-	optionalExtraSubscriptions: ClearingHouseAccountTypes[];
-
 	subscribe(
-		optionalSubscriptions?: ClearingHouseAccountTypes[]
+		optionalSubscriptions?: OptionalSubscribableClearingHouseAccountTypes[]
 	): Promise<boolean>;
 	fetch(): Promise<void>;
 	unsubscribe(): Promise<void>;
@@ -69,10 +73,11 @@ export interface ClearingHouseAccountSubscriber {
 }
 
 export interface UserAccountEvents {
-	fetched: void;
 	userAccountData: (payload: UserAccount) => void;
 	userPositionsData: (payload: UserPositionsAccount) => void;
 	update: void;
+	fetched: void;
+	fetchedAccount: SubscribableUserAccountTypes;
 }
 
 export interface UserAccountSubscriber {
@@ -85,4 +90,19 @@ export interface UserAccountSubscriber {
 
 	getUserAccount(): UserAccount;
 	getUserPositionsAccount(): UserPositionsAccount;
+}
+
+export interface PollingUserAccountSubscriber extends UserAccountSubscriber {
+
+	startPolling(account: SubscribableUserAccountTypes): boolean
+	stopPolling(account: SubscribableUserAccountTypes): boolean
+	setPollingRate(account: SubscribableUserAccountTypes, rate: number): void
+}
+
+
+export interface PollingClearingHouseAccountSubscriber extends ClearingHouseAccountSubscriber {
+
+	startPolling(account: SubscribableClearingHouseAccountTypes): boolean
+	stopPolling(account: SubscribableClearingHouseAccountTypes): boolean
+	setPollingRate(account: SubscribableClearingHouseAccountTypes, rate: number): void
 }

--- a/sdk/src/accounts/types.ts
+++ b/sdk/src/accounts/types.ts
@@ -79,8 +79,8 @@ export interface ClearingHouseAccountSubscriber {
 }
 
 export interface UserAccountEvents {
-	userAccountData: (payload: UserAccount) => void;
-	userPositionsData: (payload: UserPositionsAccount) => void;
+	userAccountUpdate: (payload: UserAccount) => void;
+	userPositionsAccountUpdate: (payload: UserPositionsAccount) => void;
 	update: void;
 	fetched: void;
 	fetchedAccount: SubscribableUserAccountTypes;

--- a/sdk/src/accounts/webSocketAccountSubscriber.ts
+++ b/sdk/src/accounts/webSocketAccountSubscriber.ts
@@ -3,6 +3,7 @@ import { Program } from '@project-serum/anchor';
 import { PublicKey } from '@solana/web3.js';
 
 export class WebSocketAccountSubscriber<T> implements AccountSubscriber<T> {
+	isSubscribed: boolean;
 	data?: T;
 	accountName: string;
 	program: Program;
@@ -18,11 +19,12 @@ export class WebSocketAccountSubscriber<T> implements AccountSubscriber<T> {
 		this.program = program;
 		this.accountPublicKey = accountPublicKey;
 	}
+	
 
 	async subscribe(onChange: (data: T) => void): Promise<void> {
 		this.onChange = onChange;
 		await this.fetch();
-
+		this.isSubscribed = true;
 		this.program.account[this.accountName]
 			.subscribe(this.accountPublicKey, this.program.provider.opts.commitment)
 			.on('change', async (data: T) => {
@@ -44,8 +46,10 @@ export class WebSocketAccountSubscriber<T> implements AccountSubscriber<T> {
 	}
 
 	unsubscribe(): Promise<void> {
-		return this.program.account[this.accountName].unsubscribe(
+		const unsubscribed = this.program.account[this.accountName].unsubscribe(
 			this.accountPublicKey
 		);
+		this.isSubscribed = false;
+		return unsubscribed;
 	}
 }

--- a/sdk/src/accounts/webSocketAccountSubscriber.ts
+++ b/sdk/src/accounts/webSocketAccountSubscriber.ts
@@ -19,7 +19,6 @@ export class WebSocketAccountSubscriber<T> implements AccountSubscriber<T> {
 		this.program = program;
 		this.accountPublicKey = accountPublicKey;
 	}
-	
 
 	async subscribe(onChange: (data: T) => void): Promise<void> {
 		this.onChange = onChange;

--- a/sdk/src/clearingHouse.ts
+++ b/sdk/src/clearingHouse.ts
@@ -40,9 +40,10 @@ import {
 	getUserAccountPublicKeyAndNonce,
 } from './addresses';
 import {
-	ClearingHouseAccountSubscriber,
 	ClearingHouseAccountEvents,
-	ClearingHouseAccountTypes,
+	OptionalSubscribableClearingHouseAccountTypes,
+	SubscribableClearingHouseAccountTypes,
+	PollingClearingHouseAccountSubscriber,
 } from './accounts/types';
 import { DefaultClearingHouseAccountSubscriber } from './accounts/defaultClearingHouseAccountSubscriber';
 import { TxSender } from './tx/types';
@@ -62,7 +63,7 @@ export class ClearingHouse {
 	public program: Program;
 	provider: Provider;
 	opts?: ConfirmOptions;
-	accountSubscriber: ClearingHouseAccountSubscriber;
+	accountSubscriber: PollingClearingHouseAccountSubscriber;
 	eventEmitter: StrictEventEmitter<EventEmitter, ClearingHouseAccountEvents>;
 	isSubscribed = false;
 	txSender: TxSender;
@@ -97,7 +98,7 @@ export class ClearingHouse {
 		connection: Connection,
 		wallet: IWallet,
 		program: Program,
-		accountSubscriber: ClearingHouseAccountSubscriber,
+		accountSubscriber: PollingClearingHouseAccountSubscriber,
 		txSender: TxSender,
 		opts: ConfirmOptions
 	) {
@@ -116,7 +117,7 @@ export class ClearingHouse {
 	 * @returns Promise<boolean> : SubscriptionSuccess
 	 */
 	public async subscribe(
-		optionalSubscriptions?: ClearingHouseAccountTypes[]
+		optionalSubscriptions?: OptionalSubscribableClearingHouseAccountTypes[]
 	): Promise<boolean> {
 		this.isSubscribed = await this.accountSubscriber.subscribe(
 			optionalSubscriptions
@@ -138,6 +139,36 @@ export class ClearingHouse {
 			'tradeHistoryAccount',
 		]);
 	}
+
+
+	/**
+	 * Used to set the polling rate of new data acquisition
+	 * @param account - which optional user account type's poll rate to set
+	 * @param pollRate - the rate at which the optional user account data will be fetched
+	 */
+	 public setPollingRate(account: SubscribableClearingHouseAccountTypes, pollRate: number): void {
+		return this.accountSubscriber.setPollingRate(account, pollRate);
+		
+	}
+
+	/**
+	 * Used to enable polling for new user account type data, set the poll rate with `setPollingRate`
+	 * @param account - which optional user account type to start polling
+	 * @return boolean - whether or not the polling was started, will return false if it was already started 
+	 */
+	public startPolling(account : SubscribableClearingHouseAccountTypes): boolean {
+		return this.accountSubscriber.startPolling(account);
+	}
+
+	/**
+	 * Disables the polling interval for the optional user account type
+	 * @returns boolean - whether or not the polling was disabled - false if there was no polling to disable
+	 */
+	public stopPolling(account : SubscribableClearingHouseAccountTypes): boolean {
+		return this.accountSubscriber.stopPolling(account);
+	}
+
+
 
 	/**
 	 *	Forces the accountSubscriber to fetch account updates from rpc

--- a/sdk/src/clearingHouse.ts
+++ b/sdk/src/clearingHouse.ts
@@ -140,23 +140,24 @@ export class ClearingHouse {
 		]);
 	}
 
-
 	/**
 	 * Used to set the polling rate of new data acquisition
 	 * @param account - which optional user account type's poll rate to set
 	 * @param pollRate - the rate at which the optional user account data will be fetched
 	 */
-	 public setPollingRate(account: SubscribableClearingHouseAccountTypes, pollRate: number): void {
+	public setPollingRate(
+		account: SubscribableClearingHouseAccountTypes,
+		pollRate: number
+	): void {
 		return this.accountSubscriber.setPollingRate(account, pollRate);
-		
 	}
 
 	/**
 	 * Used to enable polling for new user account type data, set the poll rate with `setPollingRate`
 	 * @param account - which optional user account type to start polling
-	 * @return boolean - whether or not the polling was started, will return false if it was already started 
+	 * @return boolean - whether or not the polling was started, will return false if it was already started
 	 */
-	public startPolling(account : SubscribableClearingHouseAccountTypes): boolean {
+	public startPolling(account: SubscribableClearingHouseAccountTypes): boolean {
 		return this.accountSubscriber.startPolling(account);
 	}
 
@@ -164,11 +165,9 @@ export class ClearingHouse {
 	 * Disables the polling interval for the optional user account type
 	 * @returns boolean - whether or not the polling was disabled - false if there was no polling to disable
 	 */
-	public stopPolling(account : SubscribableClearingHouseAccountTypes): boolean {
+	public stopPolling(account: SubscribableClearingHouseAccountTypes): boolean {
 		return this.accountSubscriber.stopPolling(account);
 	}
-
-
 
 	/**
 	 *	Forces the accountSubscriber to fetch account updates from rpc

--- a/sdk/src/clearingHouseUser.ts
+++ b/sdk/src/clearingHouseUser.ts
@@ -17,7 +17,11 @@ import {
 	AMM_RESERVE_PRECISION,
 	PRICE_TO_QUOTE_PRECISION,
 } from './constants/numericConstants';
-import { UserAccountEvents, PollingUserAccountSubscriber, SubscribableUserAccountTypes } from './accounts/types';
+import {
+	UserAccountEvents,
+	PollingUserAccountSubscriber,
+	SubscribableUserAccountTypes,
+} from './accounts/types';
 import { DefaultUserAccountSubscriber } from './accounts/defaultUserAccountSubscriber';
 import {
 	calculateMarkPrice,
@@ -76,17 +80,19 @@ export class ClearingHouseUser {
 	 * @param account - which optional user account type's poll rate to set
 	 * @param pollRate - the rate at which the optional user account data will be fetched
 	 */
-	public setPollingRate(account: SubscribableUserAccountTypes, pollRate: number): void {
+	public setPollingRate(
+		account: SubscribableUserAccountTypes,
+		pollRate: number
+	): void {
 		return this.accountSubscriber.setPollingRate(account, pollRate);
-		
 	}
 
 	/**
 	 * Used to enable polling for new user account type data, set the poll rate with `setPollingRate`
 	 * @param account - which optional user account type to start polling
-	 * @return boolean - whether or not the polling was started, will return false if it was already started 
+	 * @return boolean - whether or not the polling was started, will return false if it was already started
 	 */
-	public startPolling(account : SubscribableUserAccountTypes): boolean {
+	public startPolling(account: SubscribableUserAccountTypes): boolean {
 		return this.accountSubscriber.startPolling(account);
 	}
 
@@ -94,10 +100,9 @@ export class ClearingHouseUser {
 	 * Disables the polling interval for the optional user account type
 	 * @returns boolean - whether or not the polling was disabled - false if there was no polling to disable
 	 */
-	public stopPolling(account : SubscribableUserAccountTypes): boolean {
+	public stopPolling(account: SubscribableUserAccountTypes): boolean {
 		return this.accountSubscriber.stopPolling(account);
 	}
-	
 
 	/**
 	 *	Forces the accountSubscriber to fetch account updates from rpc

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -32,6 +32,24 @@ export type CandleResolution =
 	| 'W'
 	| 'M';
 
+export type SubscribableAccount =
+	| StateAccount
+	| MarketsAccount
+	| OptionalSubscribableAccount;
+
+export type OptionalSubscribableAccount =
+	| TradeHistoryAccount
+	| DepositHistoryAccount
+	| CurveHistoryAccount
+	| FundingRateHistoryAccount
+	| FundingPaymentHistoryAccount
+	| LiquidationHistoryAccount
+	| OptionalSubscribableUserAccount;
+
+export type OptionalSubscribableUserAccount =
+	| UserPositionsAccount
+	| UserAccount;
+
 // # ClearingHouse Account Types
 export type TradeHistoryAccount = {
 	head: BN;


### PR DESCRIPTION
breaking change:

`userAccountData` -> `userAccountUpdate`
`userPositionsData` -> `userPositionsAccountUpdate`

These two event naming changes were to keep the event names more consistent between user and clearing house. AcountUpdate is appended.

I tried running this with all users being polled, and it was very tolling on my system. Use this with caution and friendly values.

AccountSubscriber<T> moved into map for both clearingHouse and user.


Fetched doesn't mean that there was necessarily any new data. You can still use polling and listen to `userAccountUpdate` or `userPositionsAccountUpdate` which will still be fired. Same thing goes for clearingHouse.

This example is to show the timing of the polling is consistent with the polling rate, fetchedAccount is emitted each time any polled account is fetched for a user/clearingHouse. So, you should only need to listen to the event once. The accountType will help you figure out what account was fetched. 

```typescript
user.subscribe().then(() => {
    user.setPollingRate('userAccount', 10000);
    const startedPolling = user.startPolling('userAccount');
    if (startedPolling) {
         console.log('started polling user');
         let startTime = process.hrtime();
         user.accountSubscriber.eventEmitter.on('fetchedAccount', (accountType) => {
             let timeSinceStart = process.hrtime(startTime);
             startTime = process.hrtime();
             console.log('user ' + accountType.toString() + ' fetch took: ' + timeSinceStart[0] * 1000 + ' ms.')
         })
         user.accountSubscriber.eventEmitter.on('userAccountUpdate', (userAccount) => {
             console.log('user account data was updated');
         })
    }
})
```

```typescript
clearingHouse.subscribe(["liquidationHistoryAccount"]).then(() => {
    
    clearingHouse.setPollingRate('liquidationHistoryAccount', 10000);
    const startedPolling = clearingHouse.startPolling('liquidationHistoryAccount');

    clearingHouse.accountSubscriber.eventEmitter.on('fetchedAccount', (accountType) => {
        console.log('fetched account ' + accountType);
        const stopPolling = clearingHouse.stopPolling('liquidationHistoryAccount');
    })
})
```

