### PR TITLE
basic websocket Fetch error handling

### DIFF
--- a/sdk/src/accounts/webSocketAccountSubscriber.ts
+++ b/sdk/src/accounts/webSocketAccountSubscriber.ts
@@ -31,7 +31,7 @@ export class WebSocketAccountSubscriber<T> implements AccountSubscriber<T> {
 			});
 	}
 
-	async fetch(): Promise<void> {
+	async fetch(retryAttempt = 0): Promise<void> {
 		try {
 			const newData = (await this.program.account[this.accountName].fetch(
 				this.accountPublicKey
@@ -44,6 +44,11 @@ export class WebSocketAccountSubscriber<T> implements AccountSubscriber<T> {
 			}
 		} catch (error) {
 			console.error(error)
+			if (retryAttempt < 5) {
+				setTimeout(() => {
+					this.fetch(retryAttemp+1)
+				}, 1000 * retryAttempt)
+			}
 		}
 	}
 

--- a/sdk/src/accounts/webSocketAccountSubscriber.ts
+++ b/sdk/src/accounts/webSocketAccountSubscriber.ts
@@ -32,14 +32,18 @@ export class WebSocketAccountSubscriber<T> implements AccountSubscriber<T> {
 	}
 
 	async fetch(): Promise<void> {
-		const newData = (await this.program.account[this.accountName].fetch(
-			this.accountPublicKey
-		)) as T;
+		try {
+			const newData = (await this.program.account[this.accountName].fetch(
+				this.accountPublicKey
+			)) as T;
 
-		// if data has changed trigger update
-		if (JSON.stringify(newData) !== JSON.stringify(this.data)) {
-			this.data = newData;
-			this.onChange(this.data);
+			// if data has changed trigger update
+			if (JSON.stringify(newData) !== JSON.stringify(this.data)) {
+				this.data = newData;
+				this.onChange(this.data);
+			}
+		} catch (error) {
+			console.error(error)
 		}
 	}
 


### PR DESCRIPTION
Added a try-catch to handle any fetch error... mainly ETIMEDOUT and ECONNRESET

Without this my entire bot crashes :) Would rather have the error happen + logged and move on!

What would be better is to have a onError callback registered so that the developer using the sdk can decide what to do when the error occurs!

```
Error: failed to get info about account FExhvPycCCwYnZGeDsVtLhpEQ3yEkVY2k1HuPyfLj91L: FetchError: request to https://ssc-dao.genesysgo.net/ failed, reason: connect ETIMEDOUT 139.178.84.43:443
    at Connection.getAccountInfo (node_modules\@solana\web3.js\src\connection.ts:2483:13)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async AccountClient.getAccountInfo (node_modules\@drift-labs\sdk\node_modules\@project-serum\anchor\src\program\namespace\account.ts:351:12)
    at async AccountClient.fetchNullable (node_modules\@drift-labs\sdk\node_modules\@project-serum\anchor\src\program\namespace\account.ts:140:25)
    at async AccountClient.fetch (node_modules\@drift-labs\sdk\node_modules\@project-serum\anchor\src\program\namespace\account.ts:165:18)
```