### PR TITLE
sdk: add calculateClientCollateralSize

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -10,6 +10,7 @@ export * from './addresses';
 export * from './admin';
 export * from './clearingHouseUser';
 export * from './clearingHouse';
+export * from './math/collateral';
 export * from './math/conversion';
 export * from './math/funding';
 export * from './math/insuranceFund';

--- a/sdk/src/math/collateral.ts
+++ b/sdk/src/math/collateral.ts
@@ -1,0 +1,28 @@
+import { MarketsAccount, StateAccount } from '../types';
+import BN from 'bn.js';
+import { Connection } from '@solana/web3.js';
+
+/**
+ * Client collateral is represented by the balance of the collateral wallet, as specified in the state, minus the sum of
+ * each markets undistributed fees.
+ *
+ * @param connection
+ * @param state
+ * @param marketsAccount
+ * @returns Precision : QUOTE_ASSET_PRECISION
+ */
+export async function calculateClientCollateralSize(
+	connection: Connection,
+	state: StateAccount,
+	marketsAccount: MarketsAccount
+): Promise<BN> {
+	const collateralVaultPublicKey = state.collateralVault;
+	const collateralVaultAmount = new BN(
+		(
+			await connection.getTokenAccountBalance(collateralVaultPublicKey)
+		).value.amount
+	);
+	return marketsAccount.markets.reduce((collateralVaultAmount, market) => {
+		return collateralVaultAmount.sub(market.amm.totalFee.div(new BN(2)));
+	}, collateralVaultAmount);
+}


### PR DESCRIPTION
New helper method I am using in the [discord bot](https://github.com/DaemonWAGMI/drift-discord-bot), figured it might make sense to add directly to the SDK.