### PR TITLE
sdk: prevent bulkAccountLoader from hanging

### DIFF
--- a/sdk/src/util/promiseTimeout.ts
+++ b/sdk/src/util/promiseTimeout.ts
@@ -1,0 +1,14 @@
+export function promiseTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number
+): Promise<T | null> {
+	let timeoutId: ReturnType<typeof setTimeout>;
+	const timeoutPromise: Promise<null> = new Promise((resolve) => {
+		timeoutId = setTimeout(() => resolve(null), timeoutMs);
+	});
+
+	return Promise.race([promise, timeoutPromise]).then((result: T | null) => {
+		clearTimeout(timeoutId);
+		return result;
+	});
+}


### PR DESCRIPTION
1) clear the `loadingPromise` after a minute
2) add a timeout to the call to `getMultipleAccounts`