### PR TITLE
test-scripts: fix expireOrders test-file reference

### DIFF
--- a/test-scripts/run-anchor-tests.sh
+++ b/test-scripts/run-anchor-tests.sh
@@ -4,7 +4,7 @@ if [ "$1" != "--skip-build" ]
     cp target/idl/clearing_house.json sdk/src/idl/
 fi
 
-test_files=(order.ts orderReferrer.ts marketOrder.ts triggerOrders.ts stopLimits.ts userOrderId.ts makerOrder.ts roundInFavorBaseAsset.ts marketOrderBaseAssetAmount.ts expireOrders oracleOffsetOrders.ts clearingHouse.ts pyth.ts userAccount.ts admin.ts updateK.ts adminWithdraw.ts curve.ts whitelist.ts fees.ts idempotentCurve.ts maxDeposit.ts maxPositions.ts maxReserves.ts twapDivergenceLiquidation.ts oraclePnlLiquidation.ts whaleLiquidation.ts roundInFavor.ts minimumTradeSize.ts cappedSymFunding.ts)
+test_files=(order.ts orderReferrer.ts marketOrder.ts triggerOrders.ts stopLimits.ts userOrderId.ts makerOrder.ts roundInFavorBaseAsset.ts marketOrderBaseAssetAmount.ts expireOrders.ts oracleOffsetOrders.ts clearingHouse.ts pyth.ts userAccount.ts admin.ts updateK.ts adminWithdraw.ts curve.ts whitelist.ts fees.ts idempotentCurve.ts maxDeposit.ts maxPositions.ts maxReserves.ts twapDivergenceLiquidation.ts oraclePnlLiquidation.ts whaleLiquidation.ts roundInFavor.ts minimumTradeSize.ts cappedSymFunding.ts)
 
 for test_file in ${test_files[@]}; do
   export ANCHOR_TEST_FILE=${test_file} && anchor test --skip-build || exit 1;


### PR DESCRIPTION
smol fix: `expireOrders` is missing a `.ts` in order to run. 

Currently results in the following error:
`Error: No test files found: "./tests/expireOrders"`